### PR TITLE
I've implemented core Fibonacci Heap operations and tests.

### DIFF
--- a/fibonacci_heap.c
+++ b/fibonacci_heap.c
@@ -1,9 +1,19 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h> // Added for malloc
+#include <string.h> // Added for memset
+#include <math.h>   // Added for log2 (though using fixed size array for now)
+#include <limits.h> // Added for INT_MIN
+#include <stdio.h>  // Added for fprintf in delete_fib_node
 #include "fibonacci_heap.h"
 
 // Struct definitions are now in fibonacci_heap.h
+
+// Forward declarations for helper functions
+static void link_fib_nodes(Fibonacci_Heap *fh, Fibonacci_Node *y, Fibonacci_Node *x);
+static void consolidate_fib_heap(Fibonacci_Heap *fh);
+static void cut_fib_node(Fibonacci_Heap *fh, Fibonacci_Node *x, Fibonacci_Node *y);
+static void cascading_cut_fib_node(Fibonacci_Heap *fh, Fibonacci_Node *y);
 
 // Function to create an empty Fibonacci heap
 Fibonacci_Heap *create_fib_heap() {
@@ -65,10 +75,523 @@ bool insert_fib_heap(Fibonacci_Heap *fh, void *data) {
     return true;
 }
 
+// Function to delete a specific node from the Fibonacci heap
+bool delete_node_fib_heap(Fibonacci_Heap *fh, Fibonacci_Node *node) {
+    // a. Handle NULL inputs
+    if (fh == NULL || node == NULL) {
+        return false;
+    }
+
+    // b. Create a "negative infinity" key
+    int *neg_inf_key = (int *)malloc(sizeof(int));
+    if (!neg_inf_key) {
+        return false; // Memory allocation failed
+    }
+    *neg_inf_key = INT_MIN;
+
+    // c. Call decrease_key_fib_heap(fh, node, neg_inf_key)
+    // Note: The current decrease_key_fib_heap does not free the old key.
+    // This is a potential memory leak if the original key of 'node' was dynamically allocated
+    // and is not referenced elsewhere. For the purpose of this function, we assume
+    // that the key being replaced by neg_inf_key will be managed or is not a leak concern here,
+    // or that decrease_key should ideally handle freeing the old key if it takes ownership of the new one.
+    // Given the current API, `node->key` is simply overwritten.
+    // Let's store the old key to free it *if* decrease_key succeeds and the node's key was changed.
+    // However, the problem asks to free neg_inf_key, implying it's the one passed around.
+    // The current decrease_key will make node->key = neg_inf_key.
+    
+    void* old_key_of_node = node->key; // Store to potentially free if it's orphaned.
+                                     // This step is complex because we don't know if old_key_of_node
+                                     // should be freed by this function. Typically, data stored in a generic
+                                     // data structure is managed by the user.
+                                     // For the specific case of delete, the node (and its key) is being removed.
+                                     // If extract_min frees the node structure but returns the key,
+                                     // and if this key was `neg_inf_key`, then `neg_inf_key` is freed.
+                                     // What about the original `old_key_of_node`? It's now orphaned.
+                                     // This suggests that keys should probably always be freed by extract_min
+                                     // if they are considered "owned" by the heap.
+                                     // For now, let's follow the exact instructions which focus on neg_inf_key.
+
+    if (!decrease_key_fib_heap(fh, node, (void *)neg_inf_key)) {
+        free(neg_inf_key); // Decrease key failed
+        return false;
+    }
+    // Now node->key is neg_inf_key, and node is (or will be) fh->min.
+
+    // d. Call void* extracted_key = extract_min_fib_heap(fh)
+    void *extracted_key = extract_min_fib_heap(fh);
+
+    // e. Free the neg_inf_key
+    if (extracted_key == neg_inf_key) {
+        free(extracted_key); // extracted_key is neg_inf_key
+    } else {
+        // This case should ideally not happen if decrease_key and extract_min work as expected.
+        // If extract_min returned something else, but we successfully decreased the key to INT_MIN,
+        // then fh->min should have been 'node' and its key 'neg_inf_key'.
+        // If extract_min returned a *different* key, it implies an issue.
+        // We must still free neg_inf_key as it was allocated here.
+        free(neg_inf_key);
+        // And what about extracted_key? If it's not neg_inf_key, it's some other key
+        // that extract_min expects the caller to manage. This scenario indicates inconsistency.
+        // For robustness, if extracted_key is not neg_inf_key, it implies it might be the
+        // original key of some other node if INT_MIN wasn't truly minimal, or an error.
+        // The problem statement implies extracted_key WILL be neg_inf_key.
+    }
+    
+    // What about old_key_of_node? If it wasn't neg_inf_key (which it wouldn't be initially),
+    // and node->key was overwritten by neg_inf_key, then old_key_of_node is orphaned.
+    // The problem description does not explicitly state to free old_key_of_node.
+    // This is a common challenge with generic data structures.
+    // If the heap "owns" the keys, then extract_min or delete should free them.
+    // If the user "owns" them, they should get them back to free them.
+    // Here, extract_min returns the key, suggesting user might need to free it.
+    // Since we are deleting the node, its original key should also be considered for freeing.
+    // However, sticking to the letter: only neg_inf_key is mentioned for freeing by this function.
+
+    // f. Return true
+    return true;
+}
+
+// Placeholder function to delete a node by its data content
+bool delete_fib_node(Fibonacci_Heap *fh, void *data) {
+    // This function requires finding the node by its data.
+    // A direct search (e.g., traversing the heap) can be O(n) and is not
+    // implemented here. To use deletion, obtain a Fibonacci_Node* pointer
+    // and use delete_node_fib_heap.
+    // For now, this function will return false as node search is not implemented.
+    if (fh == NULL || data == NULL) return false; // Basic check
+    
+    // Placeholder: A real implementation would search for the node with 'data'.
+    // Fibonacci_Node *node_to_delete = find_node_by_data(fh, data); // Hypothetical search
+    // if (node_to_delete == NULL) return false; // Not found
+    // return delete_node_fib_heap(fh, node_to_delete);
+
+    fprintf(stderr, "delete_fib_node by data is not fully implemented due to missing search functionality.\n");
+    return false; 
+}
+
+// Placeholder function to change the value of a node in the Fibonacci heap
+bool change_fib_node_value(Fibonacci_Heap *fh, void *old_val, void *new_val) {
+    if (fh == NULL || old_val == NULL || new_val == NULL) {
+        return false;
+    }
+
+    // To implement change_fib_node_value:
+    // 1. Find the Fibonacci_Node* associated with old_val. This requires a search
+    //    mechanism (e.g., iterating through the heap or using an auxiliary data structure),
+    //    which can be complex or inefficient (O(n) for simple iteration) and is not
+    //    currently implemented.
+    //    Example: Fibonacci_Node *node = find_node_by_data(fh, old_val); // Hypothetical
+    //    if (node == NULL) return false; // Node with old_val not found
+
+    // 2. Once the node is found, compare new_val with the node's current key.
+    //    Let's assume integer keys for discussion:
+    //    if (*(int*)new_val < *(int*)(node->key)) { // new_val is smaller
+    //        // Call decrease_key_fib_heap.
+    //        // Note: decrease_key_fib_heap takes Fibonacci_Node*, not void* data.
+    //        // The current key of the node (node->key) would be replaced by new_val.
+    //        // The caller would be responsible for freeing the memory of the old node->key if needed.
+    //        // return decrease_key_fib_heap(fh, node, new_val);
+    //    } else if (*(int*)new_val > *(int*)(node->key)) { // new_val is larger
+    //        // This is more complex. It involves deleting the node and re-inserting
+    //        // a new node with new_val.
+    //        // The original key of the node (node->key) would need to be handled (e.g. freed by caller or by delete).
+    //        // bool deleted = delete_node_fib_heap(fh, node);
+    //        // if (!deleted) return false;
+    //        // The user must manage the memory for old_val (which is node->key).
+    //        // Typically, if delete_node_fib_heap is called, the key associated with the
+    //        // node is orphaned (as per current delete_node_fib_heap logic which uses INT_MIN).
+    //        // The user should free old_val if it's dynamically allocated.
+    //        // return insert_fib_heap(fh, new_val);
+    //    } else { // new_val is the same as current node->key
+    //        return true; // Values are the same, no change needed.
+    //    }
+
+    fprintf(stderr, "change_fib_node_value is not fully implemented due to missing node search functionality and the complex logic for value updates (decrease vs delete/insert).\n");
+    return false;
+}
+
 // Function to get the minimum key from the Fibonacci heap
 void *get_min(Fibonacci_Heap *fh) {
     if (fh == NULL || fh->min == NULL) {
         return NULL; // Heap is empty or invalid
     }
     return fh->min->key;
+}
+
+// Helper function to link node y to node x as a child of x
+static void link_fib_nodes(Fibonacci_Heap *fh, Fibonacci_Node *y, Fibonacci_Node *x) {
+    // a. Remove y from the root list
+    y->left->right = y->right;
+    y->right->left = y->left;
+
+    // If y was fh->root_list, and y is not the only node, update fh->root_list
+    // This specific check might be better handled in consolidate or extract_min
+    // For now, we assume fh->root_list will be correctly repointed by the caller (consolidate)
+    // if y happened to be the fh->root_list.
+
+    // b. Make y a child of x
+    y->parent = x;
+    if (x->child == NULL) {
+        x->child = y;
+        y->left = y;
+        y->right = y;
+    } else {
+        // Add y to x's child list (insert y to the right of x->child)
+        y->right = x->child->right;
+        y->left = x->child;
+        x->child->right->left = y;
+        x->child->right = y;
+    }
+
+    // c. Increment x->degree
+    x->degree++;
+
+    // d. Set y->marked = false
+    y->marked = false;
+}
+
+// Helper function to consolidate the root list
+static void consolidate_fib_heap(Fibonacci_Heap *fh) {
+    if (fh == NULL || fh->root_list == NULL) {
+        return;
+    }
+
+    // Max degree is roughly log_phi(n). For simplicity, use a fixed large enough array.
+    // D(n) <= log_phi(n). For n = 2^64 (max for unsigned long long), log_phi(n) approx 92.
+    // A more common practical limit for competitive programming might be n ~ 10^6, log_phi(10^6) ~ 28.
+    // Let's use 64 as a fixed size, which should be safe for typical integer counts.
+    const int MAX_DEGREE_ESTIMATE = 64; // Max degree for n up to approx 2^44
+    Fibonacci_Node *A[MAX_DEGREE_ESTIMATE];
+    memset(A, 0, sizeof(A)); // Initialize A with NULLs (0 for pointers)
+
+    Fibonacci_Node *current_root = fh->root_list;
+    if (current_root == NULL) return;
+
+    // Need to iterate through all root nodes.
+    // Since the list is circular and modified during iteration (nodes removed by link_fib_nodes),
+    // it's safer to collect them first or carefully manage iteration.
+    // Let's create a temporary array of root nodes to iterate over.
+    // Count root nodes first
+    int num_roots = 0;
+    Fibonacci_Node *temp = current_root;
+    do {
+        num_roots++;
+        temp = temp->right;
+    } while (temp != current_root);
+
+    Fibonacci_Node **roots_to_process = (Fibonacci_Node **)malloc(num_roots * sizeof(Fibonacci_Node *));
+    if (roots_to_process == NULL) {
+        // Memory allocation failed, cannot proceed with consolidation robustly.
+        // This is a critical error. For now, just return, but a real system might need error handling.
+        return;
+    }
+    temp = current_root;
+    for (int i = 0; i < num_roots; i++) {
+        roots_to_process[i] = temp;
+        temp = temp->right;
+    }
+
+    // b. For each node w in the original root list
+    for (int i = 0; i < num_roots; i++) {
+        Fibonacci_Node *x = roots_to_process[i];
+
+        // Ensure x is still in the root list (it might have been linked as a child)
+        // A simple check: if x has a parent, it's no longer a root in the main list.
+        if (x->parent != NULL) {
+            continue;
+        }
+
+        int d = x->degree;
+        while (A[d] != NULL) {
+            Fibonacci_Node *y = A[d]; // y is the other node with the same degree
+
+            // Ensure x and y are different nodes. This should always be true if logic is correct.
+            if (x == y) {
+                 // This case should ideally not happen if nodes are processed correctly.
+                 // If it does, break to avoid infinite loop.
+                break;
+            }
+
+            if (*(int *)(x->key) > *(int *)(y->key)) {
+                Fibonacci_Node *temp_node = x;
+                x = y;
+                y = temp_node;
+            }
+            // Now x->key <= y->key, so y will become child of x
+            link_fib_nodes(fh, y, x); // y is removed from root list here
+                                      // x's degree is incremented inside link_fib_nodes
+            A[d] = NULL;
+            d++; // Degree of x has increased
+            if (d >= MAX_DEGREE_ESTIMATE) {
+                // Degree exceeds array bounds, something is wrong or MAX_DEGREE_ESTIMATE is too small.
+                // Handle error or resize A if it were dynamic. For fixed size, this is an issue.
+                // This could happen if MAX_DEGREE_ESTIMATE is too small for fh->n.
+                // For now, we'll assume it's large enough.
+                break; // Avoid array out of bounds
+            }
+        }
+        A[d] = x;
+    }
+    free(roots_to_process);
+
+    // c. Reconstruct the root list from array A
+    fh->min = NULL;
+    fh->root_list = NULL; // Reset root list
+
+    for (int d = 0; d < MAX_DEGREE_ESTIMATE; d++) {
+        if (A[d] != NULL) {
+            Fibonacci_Node *node_to_add = A[d];
+            // Ensure node_to_add is properly a root
+            node_to_add->parent = NULL;
+            // Add A[d] to the root list
+            if (fh->root_list == NULL) {
+                fh->root_list = node_to_add;
+                node_to_add->left = node_to_add;
+                node_to_add->right = node_to_add;
+            } else {
+                // Insert node_to_add to the right of fh->root_list
+                node_to_add->right = fh->root_list->right;
+                node_to_add->left = fh->root_list;
+                fh->root_list->right->left = node_to_add;
+                fh->root_list->right = node_to_add;
+            }
+
+            // Update fh->min
+            if (fh->min == NULL || *(int *)(node_to_add->key) < *(int *)(fh->min->key)) {
+                fh->min = node_to_add;
+            }
+        }
+    }
+    // If fh->root_list was reconstructed, fh->min is now set.
+    // If the heap became empty (e.g. extracting last element, though consolidate is not directly for that)
+    // then fh->min and fh->root_list will be NULL.
+    // The problem statement said "fh->root_list points to a valid node ... (e.g. fh->min)"
+    // If fh->min is set, fh->root_list can be fh->min.
+    // Our current reconstruction makes fh->root_list point to the *last* node added from A.
+    // It's fine as long as it's a valid entry point.
+    // For consistency, let's make fh->root_list = fh->min if fh->min is not NULL.
+    if (fh->min != NULL) {
+        fh->root_list = fh->min;
+    } else {
+        fh->root_list = NULL; // Should already be NULL if fh->min is NULL
+    }
+}
+
+// Function to decrease the key of a node in the Fibonacci heap
+bool decrease_key_fib_heap(Fibonacci_Heap *fh, Fibonacci_Node *node, void *new_key) {
+    // a. Basic checks
+    if (fh == NULL || node == NULL || new_key == NULL) {
+        return false; // Invalid input
+    }
+    if (*(int *)new_key > *(int *)(node->key)) {
+        return false; // New key is greater than current key
+    }
+
+    // b. Update the key
+    node->key = new_key;
+
+    // c. Let y = node->parent
+    Fibonacci_Node *y = node->parent;
+
+    // d. If node is not a root and its key is now less than its parent's key
+    if (y != NULL && (*(int *)(node->key) < *(int *)(y->key))) {
+        // i. Call cut_fib_node(fh, node, y)
+        cut_fib_node(fh, node, y);
+        // ii. Call cascading_cut_fib_node(fh, y)
+        cascading_cut_fib_node(fh, y);
+    }
+
+    // e. Update fh->min
+    // This check is important even if the node was already a root, or if it became a root.
+    if (fh->min == NULL || (*(int *)(node->key) < *(int *)(fh->min->key))) {
+        fh->min = node;
+    }
+
+    // f. Return true
+    return true;
+}
+
+// Function to extract the minimum key from the Fibonacci heap
+void *extract_min_fib_heap(Fibonacci_Heap *fh) {
+    if (fh == NULL) return NULL;
+
+    // a. Let z be fh->min
+    Fibonacci_Node *z = fh->min;
+
+    // b. If z is NULL (heap is empty), return NULL
+    if (z == NULL) {
+        return NULL;
+    }
+
+    // c. Store z->key to be returned later
+    void *min_key = z->key;
+    bool z_had_children = (z->child != NULL); // Track if z initially had children
+
+    // d. If z has children (i.e., z->child is not NULL):
+    if (z_had_children) {
+        Fibonacci_Node *child = z->child;
+        Fibonacci_Node *first_child = child; // To detect cycle completion
+        Fibonacci_Node *next_child;
+
+        // Need to save children before modifying lists extensively
+        // Count children first
+        int num_children = 0;
+        do {
+            num_children++;
+            child = child->right;
+        } while (child != first_child);
+        
+        Fibonacci_Node **children_array = (Fibonacci_Node **)malloc(num_children * sizeof(Fibonacci_Node *));
+        if (children_array == NULL && num_children > 0) {
+            // Memory allocation failed, cannot proceed safely.
+            // This is a critical error state. For now, return NULL as we can't correctly modify the heap.
+            return NULL; 
+        }
+
+        child = first_child;
+        for(int i=0; i < num_children; ++i) {
+            children_array[i] = child;
+            child = child->right;
+        }
+
+        for (int i = 0; i < num_children; ++i) {
+            Fibonacci_Node *current_child_to_add = children_array[i];
+            // i. Add current_child_to_add to the root list of fh
+            if (fh->root_list == NULL) { // If root list is currently empty (e.g. z was the only root)
+                fh->root_list = current_child_to_add;
+                current_child_to_add->left = current_child_to_add;
+                current_child_to_add->right = current_child_to_add;
+            } else {
+                // Insert current_child_to_add to the right of fh->root_list
+                current_child_to_add->left = fh->root_list;
+                current_child_to_add->right = fh->root_list->right;
+                fh->root_list->right->left = current_child_to_add;
+                fh->root_list->right = current_child_to_add;
+            }
+            // Set current_child_to_add->parent = NULL
+            current_child_to_add->parent = NULL;
+        }
+        
+        if(num_children > 0) free(children_array);
+
+        // ii. Clear z->child (it no longer has children in the heap structure)
+        z->child = NULL; // z->degree is not explicitly reset here as z is removed.
+    }
+
+    // e. Remove z from the root list
+    if (z == z->right) { // z is the only node in the root list
+        // This means if z had children, they are now the root list.
+        // If z had no children, the root list is now empty.
+        if (z_had_children) {
+            // fh->root_list was set to one of the children (or is NULL if z had no children)
+            // fh->min will be found by consolidate.
+            // The loop above already made fh->root_list point to one of the children if any.
+        } else {
+            // z was the only node and had no children.
+            fh->min = NULL;
+            fh->root_list = NULL;
+        }
+    } else { // z has siblings in the root list
+        z->left->right = z->right;
+        z->right->left = z->left;
+        
+        // If fh->root_list was z, point it to another node
+        if (fh->root_list == z) {
+            fh->root_list = z->right;
+        }
+        // fh->min will be updated by consolidate. As a temporary measure,
+        // we could set fh->min = fh->root_list, but consolidate handles this.
+        // For robustness, let's ensure fh->min is not z if it's still pointing to it.
+        if (fh->min == z) { // This will always be true here
+            fh->min = fh->root_list; // Temporary new min, consolidate will find the actual one.
+                                     // If fh->root_list became NULL (e.g. z was only node, children became root list, but no children), this is fine.
+        }
+    }
+
+    // f. If z == z->right AND z->child == NULL (originally, not after children are moved)
+    // This condition means the heap had only one node (z) and it had no children.
+    // In this case, fh->root_list will be NULL at this point.
+    if (fh->root_list == NULL) { // This is a better check for emptiness now
+        fh->n = 0;
+        // fh->min is already NULL
+        free(z);
+        return min_key;
+    }
+
+    // g. Call consolidate_fib_heap(fh)
+    // consolidate_fib_heap will update fh->min and ensure fh->root_list points to the new min.
+    consolidate_fib_heap(fh);
+
+    // h. Decrement fh->n
+    fh->n--;
+
+    // i. Free the extracted node z
+    free(z);
+
+    // j. Return the stored key
+    return min_key;
+}
+
+// Helper function to cut node x from its parent y
+static void cut_fib_node(Fibonacci_Heap *fh, Fibonacci_Node *x, Fibonacci_Node *y) {
+    // a. Remove x from y's child list
+    if (x == x->right) { // x is the only child of y
+        y->child = NULL;
+    } else { // x has siblings
+        x->left->right = x->right;
+        x->right->left = x->left;
+        if (y->child == x) {
+            y->child = x->right; // Update y's child pointer to another child
+        }
+    }
+
+    // b. Decrement y->degree
+    y->degree--;
+
+    // c. Add x to the root list of fh
+    // Initially, x becomes its own circular list
+    x->left = x;
+    x->right = x;
+
+    if (fh->root_list == NULL) {
+        fh->root_list = x;
+        // fh->min would also be x here, but insert_fib_heap logic handles fh->min update
+        // or it will be updated when next needed e.g. by consolidate or extract_min
+    } else {
+        // Insert x to the right of fh->root_list (which is often fh->min)
+        x->right = fh->root_list->right;
+        x->left = fh->root_list;
+        fh->root_list->right->left = x;
+        fh->root_list->right = x;
+    }
+    // If fh->min needs update, it's typically done by the caller or by consolidate.
+    // However, if x's key is smaller than current fh->min, it should become fh->min.
+    // This is not explicitly stated for cut, but good for consistency.
+    // For now, let's assume fh->min update is handled by operations like decrease_key or delete,
+    // which are the typical callers of cut/cascading_cut.
+    // The primary role here is to move x to the root list.
+
+    // d. Set x->parent = NULL
+    x->parent = NULL;
+
+    // e. Set x->marked = false
+    x->marked = false;
+}
+
+// Helper function for cascading cuts
+static void cascading_cut_fib_node(Fibonacci_Heap *fh, Fibonacci_Node *y) {
+    // a. Let z = y->parent
+    Fibonacci_Node *z = y->parent;
+
+    // b. If z is not NULL (y is not a root)
+    if (z != NULL) {
+        // i. If y->marked is false
+        if (y->marked == false) {
+            y->marked = true;
+        } else { // ii. Else (y->marked is true)
+            cut_fib_node(fh, y, z);
+            cascading_cut_fib_node(fh, z);
+        }
+    }
 }

--- a/fibonacci_heap.h
+++ b/fibonacci_heap.h
@@ -32,4 +32,10 @@ bool change_fib_node_value(Fibonacci_Heap *fh, void *old_val, void *new_val);
 
 void *get_min(Fibonacci_Heap *fh);
 
+void *extract_min_fib_heap(Fibonacci_Heap *fh);
+
+bool decrease_key_fib_heap(Fibonacci_Heap *fh, Fibonacci_Node *node, void *new_key);
+
+bool delete_node_fib_heap(Fibonacci_Heap *fh, Fibonacci_Node *node);
+
 #endif // FIBONACCI_HEAP_H

--- a/test/test_fib_heap.c
+++ b/test/test_fib_heap.c
@@ -1,7 +1,15 @@
 #include <check.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "../fibonacci_heap.h"
+#include "../fibonacci_heap.h" // Already included
+
+// Helper to create an int pointer
+static int* create_int_ptr(int value) {
+    int *ptr = malloc(sizeof(int));
+    ck_assert_ptr_nonnull(ptr); // Ensure malloc was successful
+    *ptr = value;
+    return ptr;
+}
 
 // Test case for creating a Fibonacci heap
 START_TEST(test_create_heap)
@@ -75,6 +83,498 @@ START_TEST(test_get_min)
     ck_assert_int_eq(*(int*)get_min(heap), 10);
     
     // Eventually: free(val1); free(val2); free(val3); free(heap);
+    // For now, let's free them to be good citizens, assuming these tests are self-contained.
+    // However, the original file comments them out, so I will match that for now.
+    // If these were real unit tests in a larger system, freeing would be important.
+}
+END_TEST
+
+
+// Test case for extract_min function
+START_TEST(test_extract_min)
+{
+    Fibonacci_Heap *heap;
+    int *key_ptr;
+    void *extracted_key;
+
+    // Scenario 1: Extract from an empty heap
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_null(extracted_key);
+    ck_assert_int_eq(heap->n, 0);
+    ck_assert_ptr_null(heap->min);
+    ck_assert_ptr_null(heap->root_list);
+    // free(heap); // Matching style, normally would free
+
+    // Scenario 2: Extract from a single-element heap
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    key_ptr = create_int_ptr(10);
+    insert_fib_heap(heap, key_ptr);
+    ck_assert_int_eq(heap->n, 1);
+
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 10);
+    ck_assert_int_eq(heap->n, 0);
+    ck_assert_ptr_null(heap->min);
+    ck_assert_ptr_null(heap->root_list);
+    free(extracted_key); // Free the key's memory
+    // free(heap);
+
+    // Scenario 3: Extract from a multi-element heap (simple case)
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    int *val1 = create_int_ptr(10);
+    int *val2 = create_int_ptr(5);
+    int *val3 = create_int_ptr(20);
+    insert_fib_heap(heap, val1);
+    insert_fib_heap(heap, val2);
+    insert_fib_heap(heap, val3);
+    ck_assert_int_eq(heap->n, 3);
+    ck_assert_int_eq(*(int*)get_min(heap), 5);
+
+    extracted_key = extract_min_fib_heap(heap); // Extract 5
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 5);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 2);
+    ck_assert_ptr_nonnull(get_min(heap)); // Check before dereferencing
+    ck_assert_int_eq(*(int*)get_min(heap), 10);
+
+    extracted_key = extract_min_fib_heap(heap); // Extract 10
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 10);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 1);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 20);
+
+    extracted_key = extract_min_fib_heap(heap); // Extract 20
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 20);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 0);
+    ck_assert_ptr_null(heap->min);
+    ck_assert_ptr_null(heap->root_list);
+    // free(heap);
+    // Note: val1, val2, val3 were not freed here because extract_min returns the pointer
+    // and we free it there. If they weren't extracted, they'd need freeing.
+
+    // Scenario 4: Extract causing consolidation
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    // Insert 8,7,6,5,4,3,2,1 (creates 8 root nodes)
+    int *k8 = create_int_ptr(8); insert_fib_heap(heap, k8);
+    int *k7 = create_int_ptr(7); insert_fib_heap(heap, k7);
+    int *k6 = create_int_ptr(6); insert_fib_heap(heap, k6);
+    int *k5 = create_int_ptr(5); insert_fib_heap(heap, k5);
+    int *k4 = create_int_ptr(4); insert_fib_heap(heap, k4);
+    int *k3 = create_int_ptr(3); insert_fib_heap(heap, k3);
+    int *k2 = create_int_ptr(2); insert_fib_heap(heap, k2);
+    int *k1 = create_int_ptr(1); insert_fib_heap(heap, k1);
+    ck_assert_int_eq(heap->n, 8);
+    ck_assert_int_eq(*(int*)get_min(heap), 1);
+
+    // Extract 1 (causes consolidation)
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 1);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 7);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 2); // After 1 is extracted, 2 should be min
+
+    // Extract 2
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 2);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 6);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 3);
+
+    // Extract 3
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 3);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 5);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 4);
+
+    // Extract 4
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 4);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 4);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 5);
+
+    // Extract 5
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 5);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 3);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 6);
+
+    // Extract 6
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 6);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 2);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 7);
+
+    // Extract 7
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 7);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 1);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 8);
+
+    // Extract 8
+    extracted_key = extract_min_fib_heap(heap);
+    ck_assert_ptr_nonnull(extracted_key);
+    ck_assert_int_eq(*(int*)extracted_key, 8);
+    free(extracted_key);
+    ck_assert_int_eq(heap->n, 0);
+    ck_assert_ptr_null(heap->min);
+    ck_assert_ptr_null(heap->root_list);
+    // free(heap);
+    // Original key pointers k1-k8 were returned by extract_min and freed.
+}
+END_TEST
+
+// Test case for decrease_key function
+START_TEST(test_decrease_key)
+{
+    Fibonacci_Heap *heap;
+    Fibonacci_Node *node_to_decrease;
+    int *key_ptr;
+    int *new_key_ptr;
+    bool result;
+
+    // Scenario 1: Decrease key of a root node (fh->min, no cut)
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    key_ptr = create_int_ptr(10);
+    insert_fib_heap(heap, key_ptr); // Heap: 10(min)
+    int *key_ptr2 = create_int_ptr(20);
+    insert_fib_heap(heap, key_ptr2); // Heap: 10(min), 20
+    ck_assert_int_eq(heap->n, 2);
+    ck_assert_ptr_eq(heap->min->key, key_ptr); // Min is 10
+
+    node_to_decrease = heap->min; // Node with key 10
+    new_key_ptr = create_int_ptr(5);
+    result = decrease_key_fib_heap(heap, node_to_decrease, new_key_ptr);
+    ck_assert(result);
+    ck_assert_int_eq(*(int*)heap->min->key, 5);
+    ck_assert_ptr_eq(heap->min, node_to_decrease); // Node itself should be the same
+    ck_assert_int_eq(heap->n, 2);
+    // free(new_key_ptr); // new_key_ptr is now owned by the node
+    // Keys key_ptr (original 10) and key_ptr2 (20) are still in heap or their memory was transferred.
+    // If decrease_key_fib_heap re-assigned node->key, then new_key_ptr is used. The old key_ptr is effectively replaced.
+    // We need to be careful about freeing. The problem description for decrease_key implies node->key = new_key.
+    // So, the *value* pointed to by node->key changes. If new_key is a different pointer, then old node->key needs freeing.
+    // The current implementation of decrease_key is `node->key = new_key;` which means `key_ptr` (original 10) is orphaned if not freed by decrease_key.
+    // Let's assume for now that the user of decrease_key is responsible for the old key if it's not the same pointer.
+    // For this test, key_ptr was the original key. new_key_ptr is the new one.
+    // The problem description for decrease_key does not specify freeing the old key.
+    // Let's assume keys passed to insert are owned by heap, and new_key replaces the old one.
+    // We should free the orphaned key_ptr here.
+    free(key_ptr); 
+    // Clean up remaining keys for next scenario
+    free(heap->min->key); // this is new_key_ptr (5)
+    Fibonacci_Node* temp_node_for_free = heap->root_list; // find the other node
+    if (temp_node_for_free == heap->min) temp_node_for_free = temp_node_for_free->right;
+    if (temp_node_for_free != heap->min) free(temp_node_for_free->key); // this is key_ptr2 (20)
+    // free(heap); // commented out per style
+
+    // Scenario 2: Attempt to decrease key to a larger value
+    heap = create_fib_heap();
+    key_ptr = create_int_ptr(10);
+    insert_fib_heap(heap, key_ptr);
+    ck_assert_int_eq(*(int*)heap->min->key, 10);
+
+    node_to_decrease = heap->min;
+    new_key_ptr = create_int_ptr(15);
+    result = decrease_key_fib_heap(heap, node_to_decrease, new_key_ptr);
+    ck_assert(!result); // Should fail
+    ck_assert_int_eq(*(int*)heap->min->key, 10); // Key should remain 10
+    ck_assert_int_eq(heap->n, 1);
+    free(new_key_ptr); // new_key_ptr was not used by the heap
+    free(key_ptr); // key_ptr is still in the heap, free it at end of this test block
+    // free(heap);
+
+    // Scenario 6: Decrease key on NULL node or heap
+    heap = create_fib_heap();
+    key_ptr = create_int_ptr(5); // A valid key
+    Fibonacci_Node *valid_node = heap->min; // This will be NULL if heap is empty, or a node if not.
+                                         // Let's insert to make it valid for one part of test.
+    insert_fib_heap(heap, create_int_ptr(100)); // node_to_decrease will be this one.
+    node_to_decrease = heap->min;
+
+    result = decrease_key_fib_heap(NULL, node_to_decrease, key_ptr);
+    ck_assert(!result);
+    result = decrease_key_fib_heap(heap, NULL, key_ptr);
+    ck_assert(!result);
+    result = decrease_key_fib_heap(heap, node_to_decrease, NULL);
+    ck_assert(!result);
+    free(key_ptr); // Not used by heap in these calls
+    free(heap->min->key); // Free the 100
+    // free(heap);
+
+
+    // Scenario 4 (Simplified): Decrease child's key, causing a cut
+    // Setup: Insert 10 (N10), 20 (N20), 5 (N5). Min is N5.
+    // Extract Min (N5). Heap consolidates. Assume N10 is min, N20 is child of N10.
+    // (Actual consolidation can vary, this is a common outcome for specific link strategies)
+    heap = create_fib_heap();
+    int *k10 = create_int_ptr(10); insert_fib_heap(heap, k10); // N10
+    int *k20 = create_int_ptr(20); insert_fib_heap(heap, k20); // N20
+    int *k5 = create_int_ptr(5);   insert_fib_heap(heap, k5);  // N5
+    ck_assert_int_eq(*(int*)heap->min->key, 5);
+    ck_assert_int_eq(heap->n, 3);
+
+    void* extracted_val = extract_min_fib_heap(heap); // Extract 5 (k5)
+    ck_assert_ptr_nonnull(extracted_val);
+    ck_assert_int_eq(*(int*)extracted_val, 5);
+    free(extracted_val); // k5 is freed
+    ck_assert_int_eq(heap->n, 2);
+    // After extract_min, consolidation occurs.
+    // Expected: 10 is min, 20 is child of 10. (Or vice-versa if keys are same and degrees differ)
+    // Let's check current min. It should be 10.
+    ck_assert_ptr_nonnull(heap->min);
+    ck_assert_int_eq(*(int*)heap->min->key, 10); // N10 is min
+    
+    // Check if N10 has a child. This child should be N20.
+    Fibonacci_Node *parent_node = heap->min; // This is N10
+    ck_assert_ptr_nonnull(parent_node->child); // N10 should have a child
+    Fibonacci_Node *child_node_to_decrease = parent_node->child; // This should be N20
+    ck_assert_ptr_nonnull(child_node_to_decrease);
+    ck_assert_int_eq(*(int*)child_node_to_decrease->key, 20); // Verify it's N20
+    ck_assert_ptr_eq(child_node_to_decrease->parent, parent_node); // Verify parent pointer
+    ck_assert_int_eq(parent_node->degree, 1); // N10 should have degree 1
+
+    // Now, decrease key of child_node (N20) to 2. This should cause a cut.
+    int *k2 = create_int_ptr(2);
+    result = decrease_key_fib_heap(heap, child_node_to_decrease, k2);
+    ck_assert(result);
+    ck_assert_int_eq(heap->n, 2); // Still 2 nodes
+
+    // child_node_to_decrease (now with key 2) should be the new minimum and a root.
+    ck_assert_ptr_nonnull(heap->min);
+    ck_assert_int_eq(*(int*)heap->min->key, 2);
+    ck_assert_ptr_eq(heap->min, child_node_to_decrease); // The decreased node is min
+    ck_assert_ptr_null(child_node_to_decrease->parent); // It's a root now
+    ck_assert_int_eq(child_node_to_decrease->marked, false); // Cut makes it unmarked
+
+    // The original parent_node (N10) should have its degree decremented.
+    ck_assert_int_eq(parent_node->degree, 0);
+    
+    // Free keys: k10 (original key of parent_node) is still in parent_node
+    // k20 (original key of child_node_to_decrease) was replaced by k2. So k20 needs freeing.
+    free(k20);
+    // k2 is now in child_node_to_decrease (which is heap->min)
+    // k10 is in parent_node (which is some other root node)
+    // Clean up:
+    free(heap->min->key); // This is k2
+    // Find the other node (original parent_node, N10) and free its key
+    Fibonacci_Node* other_node = heap->root_list;
+    if (other_node == heap->min) other_node = other_node->right;
+    // It's possible after cut and fh->min update, that heap->min is the only node if list was small
+    if (other_node != heap->min && other_node != NULL) { // Check other_node is not same as min and not null
+         ck_assert_int_eq(*(int*)other_node->key, 10); // Should be N10
+         free(other_node->key); // This is k10
+    } else if (parent_node != heap->min) { // If parent_node itself is not the new min (which it shouldn't be)
+        // This case if heap->root_list traversal didn't find it simply.
+        // This means parent_node is the other node.
+         ck_assert_int_eq(*(int*)parent_node->key, 10);
+         free(parent_node->key);
+    }
+    // free(heap);
+
+
+    // Note on Scenarios 3 (decrease no cut) and 5 (cascading cut):
+    // These are harder to reliably set up without more direct heap manipulation tools
+    // or a very specific (and potentially fragile) sequence of operations.
+    // For example, Scenario 3 would require node->key < parent->key initially,
+    // then node->key is decreased but still node->key >= parent->key.
+    // Cascading cut requires a parent to be marked true, then one of its children cut,
+    // triggering the parent to be cut and its parent (grandparent of original child) to be checked.
+}
+END_TEST
+
+
+// Test case for delete_node_fib_heap function
+START_TEST(test_delete_node)
+{
+    Fibonacci_Heap *heap;
+    Fibonacci_Node *node_to_delete;
+    int *original_key_ptr;
+    bool result;
+
+    // Scenario 1: Delete from an empty heap (NULL node or NULL heap)
+    heap = create_fib_heap();
+    ck_assert_ptr_nonnull(heap);
+    // Create a dummy node structure for testing, but it's not actually in any heap.
+    // This is to test the function's handling of nodes not in a heap or invalid nodes.
+    // However, delete_node_fib_heap doesn't validate if node is in fh.
+    // The more direct test is with NULL node.
+    Fibonacci_Node dummy_node; 
+    dummy_node.key = create_int_ptr(1000); // give it some key
+
+    result = delete_node_fib_heap(NULL, &dummy_node);
+    ck_assert(!result);
+    result = delete_node_fib_heap(heap, NULL);
+    ck_assert(!result);
+    free(dummy_node.key);
+    // free(heap); // Per style
+
+    // Scenario 2: Delete the only node in a heap
+    heap = create_fib_heap();
+    original_key_ptr = create_int_ptr(10);
+    insert_fib_heap(heap, original_key_ptr);
+    ck_assert_int_eq(heap->n, 1);
+    node_to_delete = heap->min; // This is the node with key 10
+
+    // Save the key pointer before deletion as it will be replaced by INT_MIN temporarily
+    // and then the node containing it will be freed.
+    // The problem says "delete_node_fib_heap internally allocates an INT_MIN key and frees it."
+    // "The original key of the node being deleted is orphaned by decrease_key_fib_heap."
+    // "The tests must free these original keys."
+    // So, `original_key_ptr` is the one we need to free.
+    
+    result = delete_node_fib_heap(heap, node_to_delete);
+    ck_assert(result);
+    ck_assert_int_eq(heap->n, 0);
+    ck_assert_ptr_null(heap->min);
+    ck_assert_ptr_null(heap->root_list);
+    free(original_key_ptr); // Free the original key
+    // free(heap);
+
+    // Scenario 3: Delete the minimum node from a multi-element heap
+    heap = create_fib_heap();
+    int *k10 = create_int_ptr(10); insert_fib_heap(heap, k10);
+    int *k5 = create_int_ptr(5);   insert_fib_heap(heap, k5); // k5 is min
+    int *k20 = create_int_ptr(20); insert_fib_heap(heap, k20);
+    ck_assert_int_eq(heap->n, 3);
+    ck_assert_int_eq(*(int*)get_min(heap), 5);
+    
+    node_to_delete = heap->min; // Node with key 5
+    original_key_ptr = node_to_delete->key; // Save pointer to k5
+    
+    result = delete_node_fib_heap(heap, node_to_delete);
+    ck_assert(result);
+    ck_assert_int_eq(heap->n, 2);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 10);
+    free(original_key_ptr); // Free k5
+    // Remaining keys (k10, k20) need to be freed for cleanup
+    free(k10); 
+    free(k20);
+    // free(heap);
+
+    // Scenario 4: Delete a non-minimum root node
+    heap = create_fib_heap();
+    k5 = create_int_ptr(5);   insert_fib_heap(heap, k5);  // Min
+    k10 = create_int_ptr(10); insert_fib_heap(heap, k10); // Root
+    k20 = create_int_ptr(20); insert_fib_heap(heap, k20); // Root
+    ck_assert_int_eq(heap->n, 3);
+    ck_assert_int_eq(*(int*)heap->min->key, 5);
+
+    // Try to find N10. It could be fh->min->right or fh->min->left,
+    // as long as it's not fh->min itself.
+    node_to_delete = heap->min->right;
+    if (node_to_delete == heap->min) { // If fh->min->right was fh->min (e.g. only 1 or 2 nodes after some ops)
+        node_to_delete = heap->min->left; 
+    }
+    // Ensure we didn't pick fh->min again if there are multiple distinct nodes.
+    // This logic is a bit fragile. If only two nodes, min->right is the other node. min->left is also the other node.
+    // If 3 nodes, min->right and min->left are distinct and not min.
+    if (heap->n > 1 && node_to_delete == heap->min) {
+        // This shouldn't happen if n > 1 and list is circular correctly.
+        // For safety, if it's still min, try left (though for n=2, right and left are same non-min node)
+         node_to_delete = heap->min->left;
+    }
+    
+    // We need to ensure node_to_delete is not the min node (5)
+    // And it should be a root node.
+    ck_assert_ptr_nonnull(node_to_delete);
+    ck_assert_ptr_ne(node_to_delete, heap->min); // Ensure it's not the min node
+    ck_assert_ptr_null(node_to_delete->parent); // Ensure it's a root
+
+    original_key_ptr = node_to_delete->key; // Save its key (e.g. 10 or 20)
+    int original_key_value = *(int*)original_key_ptr;
+
+    result = delete_node_fib_heap(heap, node_to_delete);
+    ck_assert(result);
+    ck_assert_int_eq(heap->n, 2);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 5); // Min should still be 5
+    
+    // Verify the other non-min node is still present
+    bool other_node_found = false;
+    int expected_other_key = (original_key_value == 10) ? 20 : 10;
+    Fibonacci_Node *current = heap->root_list;
+    if (current != NULL) {
+        do {
+            if (*(int*)current->key == expected_other_key) {
+                other_node_found = true;
+                break;
+            }
+            current = current->right;
+        } while (current != heap->root_list);
+    }
+    ck_assert(other_node_found);
+    free(original_key_ptr); // Free the key of the deleted node (10 or 20)
+    // Free remaining keys (k5 and either k10 or k20)
+    free(k5);
+    if (original_key_value == 10) free(k20); else free(k10);
+    // free(heap);
+
+
+    // Scenario 5: Delete a child node
+    heap = create_fib_heap();
+    k10 = create_int_ptr(10); insert_fib_heap(heap, k10);
+    k20 = create_int_ptr(20); insert_fib_heap(heap, k20);
+    k5 = create_int_ptr(5);   insert_fib_heap(heap, k5);
+    ck_assert_int_eq(*(int*)heap->min->key, 5);
+    
+    void* extracted_val = extract_min_fib_heap(heap); // Extract 5 (k5)
+    free(extracted_val); // k5 is freed by test
+    ck_assert_int_eq(heap->n, 2); // Remaining: 10, 20
+    // Consolidation should make one child of other. Assume 10 is min, 20 is child.
+    Fibonacci_Node *parent_node_s5 = heap->min; // Should be N10
+    ck_assert_ptr_nonnull(parent_node_s5);
+    ck_assert_int_eq(*(int*)parent_node_s5->key, 10);
+    ck_assert_ptr_nonnull(parent_node_s5->child); // N10 should have a child
+    Fibonacci_Node *child_to_delete = parent_node_s5->child; // Should be N20
+    ck_assert_ptr_nonnull(child_to_delete);
+    ck_assert_int_eq(*(int*)child_to_delete->key, 20);
+
+    original_key_ptr = child_to_delete->key; // This is k20
+
+    result = delete_node_fib_heap(heap, child_to_delete);
+    ck_assert(result);
+    ck_assert_int_eq(heap->n, 1);
+    ck_assert_ptr_nonnull(get_min(heap));
+    ck_assert_int_eq(*(int*)get_min(heap), 10); // Min is N10
+    ck_assert_ptr_eq(heap->min, parent_node_s5);
+    ck_assert_int_eq(parent_node_s5->degree, 0); // Child was removed
+    
+    free(original_key_ptr); // Free k20
+    // Free remaining key k10
+    free(k10);
+    // free(heap);
 }
 END_TEST
 
@@ -91,12 +591,22 @@ Suite *fib_heap_suite(void)
     tc_core = tcase_create("Core");
     tcase_add_test(tc_core, test_create_heap);
     tcase_add_test(tc_core, test_insert_basic);
+    tcase_add_test(tc_core, test_extract_min);
+    tcase_add_test(tc_core, test_decrease_key);
+    tcase_add_test(tc_core, test_delete_node); // Added test_delete_node
     suite_add_tcase(s, tc_core);
 
     // Test case for get_min
     tc_get_min_case = tcase_create("GetMin"); // Use the renamed TCase variable
     tcase_add_test(tc_get_min_case, test_get_min); // test_get_min is the START_TEST block
     suite_add_tcase(s, tc_get_min_case);
+    // Note: It might be cleaner to group extract_min with other operation tests
+    // like get_min, or give it its own TCase. For now, adding to "Core" as per instruction.
+    // If extract_min had its own TCase:
+    // TCase *tc_extract_min_case = tcase_create("ExtractMin");
+    // tcase_add_test(tc_extract_min_case, test_extract_min);
+    // suite_add_tcase(s, tc_extract_min_case);
+
 
     return s;
 }


### PR DESCRIPTION
This update introduces several key functionalities to the Fibonacci Heap:

1.  Extract Min:
    - I implemented `extract_min_fib_heap` along with helper functions `link_fib_nodes` and `consolidate_fib_heap`.
    - I also added comprehensive tests for extract min, covering various scenarios including consolidation.

2.  Decrease Key:
    - I implemented `decrease_key_fib_heap` with helper functions `cut_fib_node` and `cascading_cut_fib_node`.
    - I added tests for decrease key, including cases that trigger cuts.

3.  Delete Node:
    - I implemented `delete_node_fib_heap` (takes a node pointer) using the decrease key and extract min strategy.
    - I added tests for `delete_node_fib_heap`, with careful handling of orphaned original key memory.

4.  API Updates:
    - The existing `delete_fib_node` (which takes data) and `change_fib_node_value` functions have been updated to serve as placeholders, clearly indicating that they require further implementation, primarily around node search functionality.

These changes provide a more complete set of operations for the Fibonacci Heap, with corresponding unit tests to verify correctness.